### PR TITLE
Handle failure to create voronoi diagram

### DIFF
--- a/label_centerlines/_src.py
+++ b/label_centerlines/_src.py
@@ -65,8 +65,13 @@ def get_centerline(
 
         # calculate Voronoi diagram and convert to graph but only use points
         # from within the original polygon
-        vor = Voronoi(outline_points)
-        graph = _graph_from_voronoi(vor, geom)
+        try:
+            vor = Voronoi(outline_points)
+            graph = _graph_from_voronoi(vor, geom)
+        except Exception:
+            logger.debug("Voronoi diagram could not be created")
+            raise CenterlineError("Voronoi diagram could not be created")
+
         logger.debug(
             "voronoi diagram: %s", _multilinestring_from_voronoi(vor, geom)
         )


### PR DESCRIPTION
Handle this error that we keep encountering while processing a planet file:

````
Traceback (most recent call last):
  File "/usr/lib/python3.7/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/usr/local/lib/python3.7/dist-packages/label_centerlines-0.1-py3.7.egg/label_centerlines/cli.py", line 143, in _feature_worker
    simplification, smooth
  File "/usr/local/lib/python3.7/dist-packages/label_centerlines-0.1-py3.7.egg/label_centerlines/_src.py", line 110, in get_centerline
    smooth_sigma
  File "/usr/local/lib/python3.7/dist-packages/label_centerlines-0.1-py3.7.egg/label_centerlines/_src.py", line 68, in get_centerline
    vor = Voronoi(outline_points)
  File "qhull.pyx", line 2607, in scipy.spatial.qhull.Voronoi.__init__
  File "qhull.pyx", line 357, in scipy.spatial.qhull._Qhull.__init__
scipy.spatial.qhull.QhullError: QH6154 Qhull precision error: Initial simplex is flat (facet 1 is coplanar with the interior point)
While executing:  | qhull v Qz Qc Qbb
Options selected for Qhull 2019.1.r 2019/06/21:
  run-id 7406149  voronoi  Qz-infinity-point  Qcoplanar-keep  Qbbound-last
  _pre-merge  _zero-centrum  Qinterior-keep  Pgood  _max-width 1.6
  Error-roundoff 1.2e-08  _one-merge 8.3e-08  Visible-distance 2.4e-08
  U-max-coplanar 2.4e-08  Width-outside 4.7e-08  _wide-facet 1.4e-07
  _maxoutside 9.4e-08
The input to qhull appears to be less than 3 dimensional, or a
computation has overflowed.
Qhull could not construct a clearly convex simplex from points:
- p1(v4): -8.5e+06 4.8e+06    12
- p9(v3): -8.5e+06 4.8e+06 8.5e+06
- p3(v2): -8.5e+06 4.8e+06     0
- p0(v1): -8.5e+06 4.8e+06    17
The center point is coplanar with a facet, or a vertex is coplanar
with a neighboring facet.  The maximum round off error for
computing distances is 1.2e-08.  The center point, facets and distances
to the center point are as follows:
center point -8.505e+06 4.766e+06 2.126e+06
facet p9 p3 p0 distance= -1.7e-10
facet p1 p3 p0 distance= -3.8e+02
facet p1 p9 p0 distance= -9.5e-10
facet p1 p9 p3 distance= -2.8e-10
These points either have a maximum or minimum x-coordinate, or
they maximize the determinant for k coordinates.  Trial points
are first selected from points that maximize a coordinate.
The min and max coordinates for each dimension are:
  0:  -8.505e+06  -2.225e-308  difference= 8.505e+06
  1:  4.766e+06  4.766e+06  difference= 1.64
  2:         0  8.505e+06  difference= 8.505e+06
If the input should be full dimensional, you have several options that
may determine an initial simplex:
  - use 'QJ'  to joggle the input and make it full dimensional
  - use 'QbB' to scale the points to the unit cube
  - use 'QR0' to randomly rotate the input for different maximum points
  - use 'Qs'  to search all points for the initial simplex
  - use 'En'  to specify a maximum roundoff error less than 1.2e-08.
  - trace execution with 'T3' to see the determinant for each point.
If the input is lower dimensional:
  - use 'QJ' to joggle the input and make it full dimensional
  - use 'Qbk:0Bk:0' to delete coordinate k from the input.  You should
    pick the coordinate with the least range.  The hull will have the
    correct topology.
  - determine the flat containing the points, rotate the points
    into a coordinate plane, and delete the other coordinates.
  - add one or more points to make the input full dimensional.
"""
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/usr/local/bin/label_centerlines", line 11, in <module>
    load_entry_point('label-centerlines==0.1', 'console_scripts', 'label_centerlines')()
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/label_centerlines-0.1-py3.7.egg/label_centerlines/cli.py", line 123, in main
  File "/usr/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/usr/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
scipy.spatial.qhull.QhullError: QH6154 Qhull precision error: Initial simplex is flat (facet 1 is coplanar with the interior point)
While executing:  | qhull v Qz Qc Qbb
Options selected for Qhull 2019.1.r 2019/06/21:
  run-id 7406149  voronoi  Qz-infinity-point  Qcoplanar-keep  Qbbound-last
  _pre-merge  _zero-centrum  Qinterior-keep  Pgood  _max-width 1.6
  Error-roundoff 1.2e-08  _one-merge 8.3e-08  Visible-distance 2.4e-08
  U-max-coplanar 2.4e-08  Width-outside 4.7e-08  _wide-facet 1.4e-07
  _maxoutside 9.4e-08
The input to qhull appears to be less than 3 dimensional, or a
computation has overflowed.
Qhull could not construct a clearly convex simplex from points:
- p1(v4): -8.5e+06 4.8e+06    12
- p9(v3): -8.5e+06 4.8e+06 8.5e+06
- p3(v2): -8.5e+06 4.8e+06     0
- p0(v1): -8.5e+06 4.8e+06    17
The center point is coplanar with a facet, or a vertex is coplanar
with a neighboring facet.  The maximum round off error for
computing distances is 1.2e-08.  The center point, facets and distances
to the center point are as follows:
center point -8.505e+06 4.766e+06 2.126e+06
facet p9 p3 p0 distance= -1.7e-10
facet p1 p3 p0 distance= -3.8e+02
facet p1 p9 p0 distance= -9.5e-10
facet p1 p9 p3 distance= -2.8e-10
These points either have a maximum or minimum x-coordinate, or
they maximize the determinant for k coordinates.  Trial points
are first selected from points that maximize a coordinate.
The min and max coordinates for each dimension are:
  0:  -8.505e+06  -2.225e-308  difference= 8.505e+06
  1:  4.766e+06  4.766e+06  difference= 1.64
  2:         0  8.505e+06  difference= 8.505e+06
If the input should be full dimensional, you have several options that
may determine an initial simplex:
  - use 'QJ'  to joggle the input and make it full dimensional
  - use 'QbB' to scale the points to the unit cube
  - use 'QR0' to randomly rotate the input for different maximum points
  - use 'Qs'  to search all points for the initial simplex
  - use 'En'  to specify a maximum roundoff error less than 1.2e-08.
  - trace execution with 'T3' to see the determinant for each point.
If the input is lower dimensional:
  - use 'QJ' to joggle the input and make it full dimensional
  - use 'Qbk:0Bk:0' to delete coordinate k from the input.  You should
    pick the coordinate with the least range.  The hull will have the
    correct topology.
  - determine the flat containing the points, rotate the points
    into a coordinate plane, and delete the other coordinates.
  - add one or more points to make the input full dimensional.

````