### PR TITLE
Don't exit with error if other geometry types are encountered

### DIFF
--- a/label_centerlines/_src.py
+++ b/label_centerlines/_src.py
@@ -42,7 +42,7 @@ def get_centerline(
     Raises:
     -------
     CenterlineError : if centerline cannot be extracted from Polygon
-    TypeError : if input geometry is not Polygon or MultiPolygon
+    CenterlineError : if input geometry is not Polygon or MultiPolygon
 
     """
     logger.debug("geometry type %s", geom.geom_type)
@@ -124,7 +124,7 @@ def get_centerline(
             raise CenterlineError("all subgeometries failed")
 
     else:
-        raise TypeError(
+        raise CenterlineError(
             "Geometry type must be Polygon or MultiPolygon, not %s" %
             geom.geom_type
         )


### PR DESCRIPTION
Currently if a geometry type other than a Polygon or MultiPolygon is encountered `label_centerlines` will exit with an error. This PR modifies this behavior so that it will raise an error but not exit as is done with other errors.